### PR TITLE
Switching out node-sass with sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const sass = require('node-sass')
+const sass = require('sass')
 const extend = require('extend-shallow')
 
 exports.name = 'scss'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "extend-shallow": "^3.0.2",
-    "node-sass": "^4.0.0"
+    "sass": "^1.23.7"
   },
   "name": "jstransformer-scss",
   "version": "1.0.0",


### PR DESCRIPTION
As we know, node-sass requires pre-built binaries on most common systems but on the not so common requires compilation locally. There has been a big shift in the sass world to switch over to the pure JavaScript implementation. We are now using this version here with great success on Alpine Linux, a very common flavor of Linux in containerized application environments such as Docker.