### PR TITLE
fix: use dart sass, fix abbreviated variable names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - "8"
-  - "9"
   - "10"
   - "11"
   - "12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 
 node_js:
   - "10"
-  - "11"
   - "12"
+  - "14"
+  - "15"
 
 notifications:
   email: false

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const path = require('path')
-const sass = require('node-sass')
+const sass = require('sass')
 const extend = require('extend-shallow')
 
 exports.name = 'scss'
 exports.outputFormat = 'css'
 
-exports.render = function (str, options) {
-  const input = extend({}, options, {data: str})
+exports.render = function (inputString, options) {
+  const input = extend({}, options, {data: inputString})
   const out = sass.renderSync(input)
   return {
     body: out.css.toString(),
@@ -18,12 +18,12 @@ exports.render = function (str, options) {
   }
 }
 
-exports.renderAsync = function (str, options) {
-  const input = extend({}, options, {data: str})
+exports.renderAsync = function (inputString, options) {
+  const input = extend({}, options, {data: inputString})
   return new Promise((resolve, reject) => {
-    sass.render(input, (err, out) => {
-      if (err) {
-        return reject(err)
+    sass.render(input, (error, out) => {
+      if (error) {
+        return reject(error)
       }
 
       return resolve({
@@ -54,9 +54,9 @@ exports.renderFile = function (filename, options) {
 exports.renderFileAsync = function (filename, options) {
   const input = extend({}, options, {file: path.resolve(filename)})
   return new Promise((resolve, reject) => {
-    sass.render(input, (err, out) => {
-      if (err) {
-        return reject(err)
+    sass.render(input, (error, out) => {
+      if (error) {
+        return reject(error)
       }
 
       return resolve({

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "posttest": "xo --space=2 --no-semicolon index.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "extend-shallow": "^3.0.2",
-    "sass": "^1.32.5"
+    "extend-shallow": "^3.0.2"
   },
   "name": "jstransformer-scss",
   "version": "1.0.0",
@@ -13,6 +12,7 @@
     "index.js"
   ],
   "devDependencies": {
+    "sass": "^1.32.4",
     "test-jstransformer": "^1.1.0",
     "xo": "*"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "extend-shallow": "^3.0.2",
-    "node-sass": "^4.0.0"
+    "sass": "^1.32.5"
   },
   "name": "jstransformer-scss",
   "version": "1.0.0",
@@ -13,7 +13,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "test-jstransformer": "^1.0.0",
+    "test-jstransformer": "^1.1.0",
     "xo": "*"
   },
   "scripts": {

--- a/test/import/expected.css
+++ b/test/import/expected.css
@@ -1,16 +1,18 @@
 nav ul {
   margin: 0;
   padding: 0;
-  list-style: none; }
-
+  list-style: none;
+}
 nav li {
-  display: inline-block; }
-
+  display: inline-block;
+}
 nav a {
   display: block;
   padding: 6px 12px;
-  text-decoration: none; }
+  text-decoration: none;
+}
 
 body {
   font: 100% Helvetica, sans-serif;
-  background-color: #efefef; }
+  background-color: #efefef;
+}

--- a/test/indentedSyntax/expected.css
+++ b/test/indentedSyntax/expected.css
@@ -1,12 +1,13 @@
 nav ul {
   margin: 0;
   padding: 0;
-  list-style: none; }
-
+  list-style: none;
+}
 nav li {
-  display: inline-block; }
-
+  display: inline-block;
+}
 nav a {
   display: block;
   padding: 6px 12px;
-  text-decoration: none; }
+  text-decoration: none;
+}

--- a/test/scss/expected.css
+++ b/test/scss/expected.css
@@ -1,12 +1,13 @@
 nav ul {
   margin: 0;
   padding: 0;
-  list-style: none; }
-
+  list-style: none;
+}
 nav li {
-  display: inline-block; }
-
+  display: inline-block;
+}
 nav a {
   display: block;
   padding: 6px 12px;
-  text-decoration: none; }
+  text-decoration: none;
+}


### PR DESCRIPTION
- move from node-sass to dart sass
- variable name change: use `inputString`, `error` instead of `str`, `err` to fix [unicorm/prevent-abbreviations](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md)
- update dependencies
- fixes #29 
- also closes #5 because dart sass does not support this feature
- fixes CI (dropped support for end-of-life node versions)